### PR TITLE
Fix issue with center_screen sometimes positioning the window wierdly

### DIFF
--- a/Scripts/AutoLoads/_Themes_.gd
+++ b/Scripts/AutoLoads/_Themes_.gd
@@ -223,8 +223,9 @@ func _input(_event: InputEvent) -> void:
 		toggle_borders()
 	
 	if Input.is_action_just_pressed("center_screen"):
-		var ds = DisplayServer.screen_get_size(0)
-		get_window().position = Vector2i(ds.x/2- get_window().size.x/2,ds.y/2- get_window().size.y/2)
+		var i = DisplayServer.window_get_current_screen()
+		var ds = DisplayServer.screen_get_size(i)
+		get_window().position = DisplayServer.screen_get_position(i) + Vector2i(ds.x/2- get_window().size.x/2,ds.y/2- get_window().size.y/2)
 		window_size_changed()
 
 


### PR DESCRIPTION
I had an issue with num pad - repositioning the pngtuber window strangely. num pad - is mapped to center_screen by default and my monitors have a wonky setup with the second monitor being on the left and smaller than the primary monitor. It was hardcoded to center on monitor 0 with no monitor position offset, and since my monitor 0 was on the right and different resolution it was placing it on my second monitor slightly off screen vertically.

This change in \_Themes_.gd fixes the issue and centers it on whatever screen the window is currently in and properly accounts for monitor offset.