### PR TITLE
Fix modifier key (Shift, Alt, Ctrl) state switching 

### DIFF
--- a/Main/Scripts/main.gd
+++ b/Main/Scripts/main.gd
@@ -166,7 +166,7 @@ func _notification(what):
 	elif what == MainLoop.NOTIFICATION_APPLICATION_FOCUS_OUT:
 		rec_inp = true
 
-func _on_background_input_capture_bg_key_pressed(_node, keys_pressed):
+func _on_background_input_capture_bg_key_pressed(_node, keys_pressed : Dictionary):
 	if Global.settings_dict.checkinput:
 		var keyStrings = []
 		var costumeKeys = []
@@ -191,7 +191,13 @@ func _on_background_input_capture_bg_key_pressed(_node, keys_pressed):
 			
 		
 		for key in keyStrings:
-			var i = costumeKeys.find(key)
+			var e = InputEventKey.new()
+			e.keycode = OS.find_keycode_from_string(key)
+			e.alt_pressed = keys_pressed.get(KEY_ALT, false)
+			e.shift_pressed = keys_pressed.get(KEY_SHIFT, false)
+			e.ctrl_pressed = keys_pressed.get(KEY_CTRL, false)
+			e.meta_pressed = keys_pressed.get(KEY_META, false)
+			var i = costumeKeys.find(e.as_text())
 			if i >= 0:
 				if costumeKeys[i] not in keys:
 				#	print(keys)

--- a/Scripts/UI/States/StateRemapButton.gd
+++ b/Scripts/UI/States/StateRemapButton.gd
@@ -30,7 +30,7 @@ func _toggled(_button_pressed):
 
 func _unhandled_input(event):
 	if not event is InputEventMouseMotion:
-		if event.is_pressed():
+		if event.is_released():
 			if !get_parent().get_index() in range(Global.settings_dict.saved_inputs.size()):
 				Global.settings_dict.saved_inputs.append(event)
 			else:


### PR DESCRIPTION
Reenabled modifier keys in the binding settings by changing it from on press to on release.

Fixed modifier keys not working when the program is running in the background by building an input event with the current modifier key state so that it matches the value saved when setting the keybind.