### PR TITLE
Tweaks to pngplus importing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+/bin

--- a/Main/Scripts/SaveAndLoad.gd
+++ b/Main/Scripts/SaveAndLoad.gd
@@ -308,25 +308,29 @@ func load_pngplus_file(path):
 	for i in load_dict:
 		var sprite_obj = preload("res://Misc/SpriteObject/sprite_object.tscn").instantiate()
 		var img_data = Marshalls.base64_to_raw(load_dict[i]["imageData"])
-		var img = Image.new()
-		img.load_png_from_buffer(img_data)
-		var img_tex = ImageTexture.new()
-		img_tex.set_image(img)
-		var img_can = CanvasTexture.new()
-		img_can.diffuse_texture = img_tex
-		sprite_obj.get_node("%Sprite2D").texture = img_can
+		if (load_dict[i]["frames"] > 1): #If animated, we don't want to trim the sprite
+			var img = Image.new()
+			img.load_png_from_buffer(img_data)
+			var img_tex = ImageTexture.new()
+			img_tex.set_image(img)
+			var img_can = CanvasTexture.new()
+			img_can.diffuse_texture = img_tex
+			sprite_obj.get_node("%Sprite2D").texture = img_can
+		else:			
+			var img_can = Global.main.get_node("%FileImporter").import_png_from_buffer(img_data, "", sprite_obj)			
+			sprite_obj.get_node("%Sprite2D").texture = img_can
 		
 	#	'''
 	
 		sprite_obj.is_plus_first_import = true
 		sprite_obj.sprite_id = load_dict[i]["identification"]
 		sprite_obj.parent_id = load_dict[i]["parentId"]
-		sprite_obj.sprite_name = "Sprite " + str(i)
+		sprite_obj.sprite_name = load_dict[i]["path"].get_file().trim_suffix(".png")
 		
 		sprite_obj.dictmain.xFrq = load_dict[i]["xFrq"]
-		sprite_obj.dictmain.xAmp = load_dict[i]["xAmp"]
+		sprite_obj.dictmain.xAmp = float(load_dict[i]["xAmp"])
 		sprite_obj.dictmain.yFrq = load_dict[i]["yFrq"]
-		sprite_obj.dictmain.yAmp = load_dict[i]["yAmp"]
+		sprite_obj.dictmain.yAmp = float(load_dict[i]["yAmp"])
 		sprite_obj.dictmain.dragSpeed = load_dict[i]["drag"]
 		sprite_obj.dictmain.rdragStr = load_dict[i]["rotDrag"]
 		sprite_obj.dictmain.stretchAmount = load_dict[i]["stretchAmount"]
@@ -343,8 +347,7 @@ func load_pngplus_file(path):
 		sprite_obj.dictmain.rLimitMax = load_dict[i]["rLimitMax"]
 		sprite_obj.dictmain.z_index = load_dict[i]["zindex"]
 		sprite_obj.dictmain.position = str_to_var(load_dict[i]["pos"])
-		sprite_obj.dictmain.offset = str_to_var(load_dict[i]["offset"])
-	#	sprite_obj.dictmain.position -= str_to_var(load_dict[i]["offset"])
+		sprite_obj.dictmain.offset += str_to_var(load_dict[i]["offset"])
 
 		var test = load_dict[i]["showBlink"]
 		var test2 = load_dict[i]["showTalk"]
@@ -383,7 +386,7 @@ func load_pngplus_file(path):
 				ndict.visible = false
 			else:
 				ndict.visible = true
-			sprite_obj.states[l] = ndict
+			sprite_obj.states[int(l)] = ndict
 		Global.sprite_container.add_child(sprite_obj)
 		sprite_obj.get_node("%Sprite2D/Grab").anchors_preset = Control.LayoutPreset.PRESET_FULL_RECT
 		

--- a/Main/Scripts/main.gd
+++ b/Main/Scripts/main.gd
@@ -79,7 +79,15 @@ func add_normal_sprite():
 func _on_file_dialog_file_selected(path): 
 	match current_state:
 		State.LoadFile:
-			SaveAndLoad.load_file(path)
+			%FileImporter.trim = false
+			if path.get_extension() == "save":
+				if Themes.theme_settings.enable_trimmer:
+					sprite_path = path
+					%ConfirmTrim.popup_centered()					
+				else:					
+					SaveAndLoad.load_file(path)
+			else:
+				SaveAndLoad.load_file(path)
 		State.SaveFileAs:
 			SaveAndLoad.save_file(path)
 			

--- a/Scripts/Objects/sprite_object.gd
+++ b/Scripts/Objects/sprite_object.gd
@@ -319,11 +319,12 @@ func reparent_obj(parent):
 func zazaza(parent):
 	for i in parent:
 		if i.sprite_id == parent_id:
+			dictmain.position -= i.dictmain.offset
 			if is_plus_first_import:
 				for state in states:
 					if !state.is_empty():
 						global = global_position
-						state.position = to_local(global) - state.offset
+						state.position = dictmain.position
 
 func proper_apng_one_shot():
 	var cframe: AImgIOFrame = frames[0]


### PR DESCRIPTION
- Hooked in the option to trim sprites when we import a pngplus file. Trimming sprites will trim a sprite UNLESS it has animation frames (at which point we can't trim it). On large files this'll take awhile to load, but it's worth it for the performance optimization
- Bugfix on import - state data was not importing properly from pngplus files.
- importing pngplus files now automatically names the imported sprites after the filename of the image (so eg if it's a/b/name.png, the object name will be "name") -fixed a bug where xAmp/yAmp weren't being properly cast as floats on import (pretty sure this is very specific to if you've run stuff through resizers)

also added the binary folder to gitignore