### PR TITLE
Fix animation speed conversion on PLUS save imports.

### DIFF
--- a/Main/Scripts/SaveAndLoad.gd
+++ b/Main/Scripts/SaveAndLoad.gd
@@ -341,7 +341,12 @@ func load_pngplus_file(path):
 		sprite_obj.dictmain.stretchAmount = load_dict[i]["stretchAmount"]
 		sprite_obj.dictmain.ignore_bounce = load_dict[i]["ignoreBounce"]
 		sprite_obj.dictmain.hframes = load_dict[i]["frames"]
-		sprite_obj.dictmain.animation_speed = load_dict[i]["animSpeed"]
+
+		# convert PLUS animSpeed into Remix animation_speed (animation fps)
+		# This assumes PLUS was set to thhe default Engine.max_fps of 60.
+		var animSpeed = load_dict[i]["animSpeed"]
+		if (animSpeed != 0.0) :
+			sprite_obj.dictmain.animation_speed = 60 / int(360.0 / float(animSpeed))
 		
 		if load_dict[i]["clipped"]:
 			sprite_obj.dictmain.clip = 2

--- a/Scripts/Objects/sprite_object.gd
+++ b/Scripts/Objects/sprite_object.gd
@@ -139,7 +139,7 @@ func animation():
 			%Sprite2D.set_frame_coords(Vector2(0, 0))
 	
 	
-	$Animation.wait_time = 1/dictmain.animation_speed 
+	$Animation.wait_time = 1.0/dictmain.animation_speed 
 	$Animation.start()
 
 func _process(_delta):


### PR DESCRIPTION
REMIX uses FPS for animation speed. PLUS used a different metric the formula for converting from PLUS animation unit to fps is
Engine.max_fps / int((max(float(animSpeed),Engine.max_fps*6.0))/float(animSpeed)). Since Engine.max_fps is not saved we must assume the default value of 60 which means the formula can be reduced to 60 / int(360.0 / float(animSpeed)).

animation_speed in REMIX also does not consistently use one type of unit. It uses both Int and Float. However, if it is an int other than 1 integer division happens and the animation time fails to be set properly. So I tweaked that formula to always use float division instead.