### PR TITLE
"Pixel Art" filter

### DIFF
--- a/Scripts/Objects/append_object.gd
+++ b/Scripts/Objects/append_object.gd
@@ -28,6 +28,7 @@ func get_default_object_data() -> Dictionary:
 		comeback_speed = 0.419,
 		flip_h = false,
 		flip_v = false,
+		pixel_art = false,
 		
 		tile = 2,
 		anchor_id = null,
@@ -141,6 +142,10 @@ func get_state(id):
 			%Sprite2D.scale.y = -1
 		else:
 			%Sprite2D.scale.y = 1
+		if get_value("pixel_art"):
+			%Sprite2D.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		else:
+			%Sprite2D.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR
 		
 		if !get_value("should_blink"):
 			%Pos.show()

--- a/Scripts/Objects/sprite_object.gd
+++ b/Scripts/Objects/sprite_object.gd
@@ -11,6 +11,7 @@ func get_default_object_data() -> Dictionary:
 		follow_parent_effects = false,
 		flip_sprite_h = false,
 		flip_sprite_v = false,
+		pixel_art_sprite = false,
 		non_animated_sheet = false,
 		animate_to_mouse = false,
 		animate_to_mouse_speed = 10,
@@ -185,6 +186,11 @@ func get_state(id):
 			%Sprite2D.scale.y = -1
 		else:
 			%Sprite2D.scale.y = 1
+
+		if get_value("pixel_art_sprite"):
+			%Sprite2D.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		else:
+			%Sprite2D.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR
 
 		if get_value("advanced_lipsync"):
 			%Sprite2D.hframes = 6

--- a/Scripts/UI/RightPanel/properties_script.gd
+++ b/Scripts/UI/RightPanel/properties_script.gd
@@ -34,6 +34,7 @@ func nullfy():
 	%RotSpinBox.editable = false
 	%BlendMode.disabled = true
 	%ClipChildren.disabled = true
+	%PixelArt.disabled = true
 	%Visible.disabled = true
 	%ZOrderSpinbox.editable = false
 
@@ -58,6 +59,7 @@ func enable():
 			%RotSpinBox.editable = true
 			%BlendMode.disabled = false
 			%ClipChildren.disabled = false
+			%PixelArt.disabled = false
 			%Visible.disabled = false
 			%ZOrderSpinbox.editable = true
 			%EyeOption.disabled = false
@@ -85,6 +87,7 @@ func set_data():
 		else:
 			%ClipChildren.button_pressed = true
 			
+		%PixelArt.button_pressed = i.get_value("pixel_art_sprite")
 		%BlendMode.text = i.get_value("blend_mode")
 		%OffsetXSpinBox.value = i.get_value("offset").x
 		%OffsetYSpinBox.value = i.get_value("offset").y
@@ -428,6 +431,34 @@ func _on_flip_sprite_v_toggled(toggled_on: bool) -> void:
 			state = Global.current_state})
 			
 		UndoRedoManager.add_data_to_manager(undo_redo_data)
+
+func _on_pixel_art_toggled(toggled_on: bool) -> void:
+	if should_change:
+		var undo_redo_data : Array = []
+		for i in Global.held_sprites:
+			var og_val = i.sprite_data.duplicate()
+			if i.sprite_type == "Sprite2D":
+				i.sprite_data.pixel_art_sprite = toggled_on
+				if i.get_value("pixel_art_sprite"):
+					i.get_node("%Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+				else:
+					i.get_node("%Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR
+				StateButton.multi_edit(toggled_on, "pixel_art_sprite", i, i.states)
+				i.save_state(Global.current_state)
+
+			elif i.sprite_type == "WiggleApp":
+				i.sprite_data.pixel_art = toggled_on
+				if i.get_value("pixel_art"):
+					i.get_node("%Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+				else:
+					i.get_node("%Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR
+				StateButton.multi_edit(toggled_on, "pixel_art", i, i.states)
+				i.save_state(Global.current_state)
+			undo_redo_data.append({sprite_object = i,
+			data = i.sprite_data.duplicate(),
+			og_data = og_val,
+			data_type = "sprite_data",
+			state = Global.current_state})
 
 func _on_clip_children_toggled(toggled_on: bool) -> void:
 	if should_change:

--- a/UI/EditorUI/RightUI/Components/properties.tscn
+++ b/UI/EditorUI/RightUI/Components/properties.tscn
@@ -324,6 +324,13 @@ size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
 text = "Clip Children"
 
+[node name="PixelArt" type="CheckBox" parent="Scroll/MarginContainer/VBoxContainer/Visibilty"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Pixel Art"
+
 [node name="HSeparator" type="HSeparator" parent="Scroll/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
@@ -433,5 +440,6 @@ layout_mode = 2
 [connection signal="toggled" from="Scroll/MarginContainer/VBoxContainer/Visibilty/FlipSpriteH" to="PropertiesScript" method="_on_flip_sprite_h_toggled"]
 [connection signal="toggled" from="Scroll/MarginContainer/VBoxContainer/Visibilty/FlipSpriteV" to="PropertiesScript" method="_on_flip_sprite_v_toggled"]
 [connection signal="toggled" from="Scroll/MarginContainer/VBoxContainer/Visibilty/ClipChildren" to="PropertiesScript" method="_on_clip_children_toggled"]
+[connection signal="toggled" from="Scroll/MarginContainer/VBoxContainer/Visibilty/PixelArt" to="PropertiesScript" method="_on_pixel_art_toggled"]
 [connection signal="item_selected" from="Scroll/MarginContainer/VBoxContainer/Reactions/EyeOption" to="PropertiesScript" method="_on_eye_option_item_selected"]
 [connection signal="item_selected" from="Scroll/MarginContainer/VBoxContainer/Reactions/MouthOption" to="PropertiesScript" method="_on_mouth_option_item_selected"]


### PR DESCRIPTION
Added a new property at the "Visibility" section to apply a texture filter to the sprite, allowing pixel art to be used as sprites. With this, users are not needed to upscale those images.