### PR TITLE
fix: Import throw "Node not found"

### DIFF
--- a/Scripts/Objects/sprite_object.gd
+++ b/Scripts/Objects/sprite_object.gd
@@ -144,16 +144,18 @@ func _input(event: InputEvent) -> void:
 			dragging = false
 
 func wiggle_sprite():
-	var length : float = 0.0
-	
+	var length: float = 0.0
+
 	if get_value("wiggle_physics"):
-		if (get_parent() is Sprite2D  or get_parent() is WigglyAppendage2D) && is_instance_valid(get_parent()):
+		if (get_parent() is Sprite2D or get_parent() is WigglyAppendage2D) and is_instance_valid(get_parent()):
 			var c_parent = get_parent().owner
-			if c_parent != null && is_instance_valid(c_parent):
-				var c_parrent_length = (c_parent.get_node("Movements").glob.y - c_parent.get_node("%Drag").global_position.y)
-				var c_parrent_length2 = (c_parent.get_node("%Movements").glob.x - c_parent.get_node("%Drag").global_position.x)
-				length +=((c_parrent_length + c_parrent_length2)/50)
-	
+			if c_parent != null and is_instance_valid(c_parent):
+				var drag_node = c_parent.get_node_or_null("%Drag")
+				var movements_node = c_parent.get_node_or_null("%Movements")
+				if drag_node != null and movements_node != null:
+					var c_parrent_length = movements_node.glob.y - drag_node.global_position.y
+					var c_parrent_length2 = movements_node.glob.x - drag_node.global_position.x
+					length += (c_parrent_length + c_parrent_length2) / 50.0
 	
 	wiggle_val = lerp(wiggle_val, sin((Global.tick * get_value("wiggle_freq"))+length)*get_value("wiggle_amp"), 0.05)
 	


### PR DESCRIPTION
- Movements change to %Movements
- Instead of 2 calls now only one

When i try to import model:
```
E 0:00:15:619   sprite_object.gd:153 @ wiggle_sprite(): Node not found: "%Drag" (relative to "/root/Menu/Scene/Main/SubViewportContainer/SubViewport/Node2D/Origin/SpritesContainer/@Node2D@1278").
  <Ошибка C++>  Method/function failed. Returning: nullptr
  <Исходный код C++>scene/main/node.cpp:1963 @ get_node()
  <Трассировка стека>sprite_object.gd:153 @ wiggle_sprite()
                sprite_object.gd:118 @ _process()

E 0:00:15:619   wiggle_sprite: Invalid access to property or key 'global_position' on a base object of type 'null instance'.
  <Исходный код GDScript>sprite_object.gd:153 @ wiggle_sprite()
  <Трассировка стека>sprite_object.gd:153 @ wiggle_sprite()
                sprite_object.gd:118 @ _process()
```