### PR TITLE
Seldomskyz/perf improvements

### DIFF
--- a/Main/Scripts/monitor_tracking.gd
+++ b/Main/Scripts/monitor_tracking.gd
@@ -8,9 +8,17 @@ var coords : Vector2 = Vector2(0,0)
 var global_coords : Vector2 = Vector2(0,0)
 var screen_count = 0
 
-var _cached_screen
-var _cached_screen_size = Vector2i.MIN
+var _cached_screen_positions = {}
 
+func get_cached_screen_position(screen: int):
+	if _cached_screen_positions.has(screen):
+		return _cached_screen_positions.get(screen)
+	var position = DisplayServer.screen_get_position(screen)
+	_cached_screen_positions[screen] = position
+	return position
+	
+var _cached_screen
+var _cached_screen_size = Vector2.ZERO
 func get_screen_size():
 	if _cached_screen == current_screen:
 		return _cached_screen_size

--- a/Main/Scripts/monitor_tracking.gd
+++ b/Main/Scripts/monitor_tracking.gd
@@ -8,8 +8,24 @@ var coords : Vector2 = Vector2(0,0)
 var global_coords : Vector2 = Vector2(0,0)
 var screen_count = 0
 
+var _cached_screen
+var _cached_screen_size = Vector2i.MIN
+
+func get_screen_size():
+	if _cached_screen == current_screen:
+		return _cached_screen_size
+	_cached_screen = current_screen
+	if current_screen == Monitor.ALL_SCREENS:
+		_cached_screen_size =  DisplayServer.screen_get_size(DisplayServer.SCREEN_PRIMARY)
+	else:
+		var idx = clamp(current_screen, 0, DisplayServer.get_screen_count() - 1)
+		_cached_screen_size = DisplayServer.screen_get_size(idx)
+	return _cached_screen_size
+var viewport_mouse_position: Vector2 = Vector2.ZERO
+
 func _ready():
 	screen_count = DisplayServer.get_screen_count()
+	viewport_mouse_position = get_viewport().get_mouse_position()
 
 func _physics_process(_delta: float) -> void:
 	if current_screen == ALL_SCREENS:
@@ -17,6 +33,7 @@ func _physics_process(_delta: float) -> void:
 	else:
 		if current_screen in range(screen_count):
 			screen_based_position()
+	viewport_mouse_position = get_viewport().get_mouse_position()
 
 func mouse_in_current_screen():
 	var screen_pos = Vector2(DisplayServer.screen_get_position(current_screen)) - Vector2(1,1)

--- a/Scripts/Objects/ObjectComponents/follow_component.gd
+++ b/Scripts/Objects/ObjectComponents/follow_component.gd
@@ -81,23 +81,21 @@ func follow_calculation(_delta = 0.0):
 	if WindowHandler.windows:
 		mouse_coords = Vector2.ZERO
 		if main_marker.current_screen == Monitor.ALL_SCREENS or main_marker.mouse_in_current_screen():
-			mouse_coords = get_mouse_coords(0)
+			mouse_coords = get_mouse_coords(main_marker, 0)
 	elif main_marker.current_screen != Monitor.ALL_SCREENS:
 		if !main_marker.mouse_in_current_screen() && Global.settings_dict.snap_out_of_bounds:
 			mouse_coords = Vector2.ZERO
 		else:
-			mouse_coords = get_mouse_coords(main_marker.current_screen)
+			mouse_coords = get_mouse_coords(main_marker, main_marker.current_screen)
 	else:
-		mouse_coords = get_mouse_coords(0)
+		mouse_coords = get_mouse_coords(main_marker, 0)
 	return mouse_coords
 
-func get_mouse_coords(screen) -> Vector2:
+func get_mouse_coords(main_marker, screen) -> Vector2:
 	var coord : Vector2 = Vector2.ZERO
 	if actor.get_value("use_object_pos"):
-		
 		var offset = Vector2(DisplayServer.screen_get_position(screen))
-		coord = actor.to_local(actor.get_global_mouse_position() - (offset / Global.camera.zoom.clampf(0.001, 10.0)))
-		
+		coord = actor.to_local(main_marker.viewport_mouse_position - (offset / Global.camera.zoom.clampf(0.001, 10.0)))
 	else:
 		var viewport_size = actor.get_viewport().size
 		var origin = actor.get_global_transform_with_canvas().origin

--- a/Scripts/Objects/ObjectComponents/follow_component.gd
+++ b/Scripts/Objects/ObjectComponents/follow_component.gd
@@ -94,18 +94,18 @@ func follow_calculation(_delta = 0.0):
 func get_mouse_coords(main_marker, screen) -> Vector2:
 	var coord : Vector2 = Vector2.ZERO
 	if actor.get_value("use_object_pos"):
-		var offset = Vector2(DisplayServer.screen_get_position(screen))
+		var offset = Vector2(main_marker.get_cached_screen_position(screen))
 		coord = actor.to_local(main_marker.viewport_mouse_position - (offset / Global.camera.zoom.clampf(0.001, 10.0)))
 	else:
 		var viewport_size = actor.get_viewport().size
 		var origin = actor.get_global_transform_with_canvas().origin
 		var x_per = 1.0 - origin.x/float(viewport_size.x)
 		var y_per = 1.0 - origin.y/float(viewport_size.y)
-		var display_size = Vector2(DisplayServer.screen_get_size(screen))
+		var display_size : Vector2 = main_marker.get_screen_size()
 		var offset = Vector2(display_size.x * x_per, display_size.y * y_per)
-		var mouse_pos = Vector2(DisplayServer.mouse_get_position()) - Vector2(DisplayServer.screen_get_position(screen))
+		var mouse_pos = Vector2(DisplayServer.mouse_get_position()) - Vector2(main_marker.get_cached_screen_position(screen))
 		coord = Vector2(mouse_pos - display_size) + offset
-		
+
 	return coord
 
 func update_controller_inputs() -> void:

--- a/Scripts/Objects/ObjectComponents/follow_rotation.gd
+++ b/Scripts/Objects/ObjectComponents/follow_rotation.gd
@@ -60,13 +60,7 @@ func update_rotation(delta: float) -> void:
 			target_rot = follow_mouse_vel_rotation()
 		else:
 			var main_marker = Global.main.get_node("%Marker")
-			var screen_size = DisplayServer.screen_get_size(-1)
-			if main_marker.current_screen == Monitor.ALL_SCREENS:
-				screen_size = DisplayServer.screen_get_size(DisplayServer.SCREEN_PRIMARY)
-			else:
-				var idx = clamp(main_marker.current_screen, 0, DisplayServer.get_screen_count() - 1)
-				screen_size = DisplayServer.screen_get_size(idx)
-				
+			var screen_size = main_marker.get_screen_size()
 			mouse_coords = %FollowPosition.follow_calculation() 
 				
 			var mouse_x = mouse_coords.x

--- a/Scripts/Objects/ObjectComponents/follow_scale.gd
+++ b/Scripts/Objects/ObjectComponents/follow_scale.gd
@@ -185,12 +185,9 @@ func update_scale(delta: float) -> void:
 	modifier.scale.x = GlobalCalculations.is_nan_or_inf(lerp(modifier.scale.x, target_sx, t))
 	modifier.scale.y = GlobalCalculations.is_nan_or_inf(lerp(modifier.scale.y, target_sy, t))
 
+
 func follow_mouse_scale(mouse : Vector2, main_marker) -> Vector2:
-	var screen_size = DisplayServer.screen_get_size(-1)
-	if main_marker.current_screen == Monitor.ALL_SCREENS:
-		screen_size = DisplayServer.screen_get_size(0)
-	else:
-		screen_size = DisplayServer.screen_get_size(main_marker.current_screen)
+	var screen_size = main_marker.get_screen_size()
 
 	var center = screen_size * 0.5
 	var dist_from_center = mouse.abs() - center


### PR DESCRIPTION
Hoping to address some of https://github.com/MudkipWorld/PNGTuber-Remix/issues/80

I used the godot profiler to try and track down which calls were most expensive, and I think the issues largely stemmed from fetching the screen size, positions, and mouse coords once per frame per sprite.

Profiler before:
<img width="615" height="259" alt="image" src="https://github.com/user-attachments/assets/a62d41ee-9bc2-4ba7-9a33-cd5afebb5348" />
Profiler after:
<img width="1311" height="291" alt="image" src="https://github.com/user-attachments/assets/613c41a6-43e1-473c-ac2a-8156b60ed32d" />

The red line is the physics frame time, so ideally the blue line would always be below it if we want to maintain 60 fps.

It's still running a bit close for 60 fps on the demo model with the caching, so if more perf is needed, it might be worth considering moving some of the more math heavy functions in movements and followcomponent into c# or some other compiled language using a gdextension.