### PR TITLE
Restore Godot CI image source

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -23,9 +23,7 @@ jobs:
     name: Windows Export
     runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
-# Temp container change until upstream releases a new version
-#      image: barichello/godot-ci:${{ inputs.godot_version }}
-      image: davcri/godot-game-template-ci:${{ inputs.godot_version }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -57,9 +55,7 @@ jobs:
     name: Linux Export
     runs-on: ubuntu-24.04  # Use 24.04 with godot 4
     container:
-# Temp container change until upstream releases a new version
-#      image: barichello/godot-ci:${{ inputs.godot_version }}
-      image: davcri/godot-game-template-ci:${{ inputs.godot_version }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Godot 4.7 tag is already available on the recommended upstream https://hub.docker.com/r/barichello/godot-ci/tags , this pr reverts the temp change.