### PR TITLE
Add grid support with position snapping

### DIFF
--- a/Main/Scripts/Global.gd
+++ b/Main/Scripts/Global.gd
@@ -86,11 +86,11 @@ var settings_dict : Dictionary = {
 	dim_color = Color.DIM_GRAY,
 	auto_save = false,
 	auto_save_timer = 1.0,
-	
+
 	saved_inputs = [],
 	zoom = Vector2(1,1),
 	pan = Vector2(0, 0),
-	
+
 	should_delta = true,
 	max_fps = 60,
 	monitor = Monitor.ALL_SCREENS,
@@ -115,6 +115,19 @@ var spinbox_held : bool = false
 
 var main = null
 var sprite_container = null
+
+var grid_visible: bool = false
+var grid_snap: bool = false
+var grid_size: float = 1.0
+var grid_overlay: Node2D = null
+
+func snap_position(pos: Vector2) -> Vector2:
+	if !grid_snap or grid_size <= 0.0:
+		return pos
+	return Vector2(
+		round(pos.x / grid_size) * grid_size,
+		round(pos.y / grid_size) * grid_size
+	)
 var viewer = null
 var viewport = null
 var top_ui = null
@@ -138,7 +151,7 @@ var mesh_text_node : Node = null
 var save_path : String = ""
 var is_editor : bool = true:
 	set(x):
-		if x == is_editor: 
+		if x == is_editor:
 			is_editor = x
 			return
 		is_editor = x
@@ -172,7 +185,7 @@ func create_placeholders():
 func set_mode(new_mode) -> void:
 	if new_mode == mode: return
 	mode = new_mode
-	
+
 	match mode:
 		0:
 			get_viewport().transparent_bg = false
@@ -206,10 +219,10 @@ func set_mode(new_mode) -> void:
 				control.get_node("%BrushesPanel").show()
 				control.get_node("%BrushData").show()
 			is_editor = true
-	
+
 	for i in Global.get_tree().get_nodes_in_group("Meshes"):
 		i.get_node("%MeshEditor").queue_redraw()
-	
+
 	Settings.theme_settings.mode = mode
 	Settings.save()
 	mode_changed.emit(mode)
@@ -227,7 +240,7 @@ func load_sprite_states(state):
 	current_state = state
 	for i in get_tree().get_nodes_in_group("Sprites"):
 		i.get_state(current_state)
-		
+
 	reinfo.emit()
 	animation_state.emit(current_state)
 	light_info.emit(current_state)
@@ -237,11 +250,11 @@ func get_sprite_states(state):
 	if state != current_state:
 		for i in get_tree().get_nodes_in_group("Sprites"):
 			i.save_state(current_state)
-	
+
 	current_state = state
 	for i in get_tree().get_nodes_in_group("Sprites"):
 		i.get_state(current_state)
-	
+
 	reinfo.emit()
 	animation_state.emit(current_state)
 	light_info.emit(current_state)
@@ -298,8 +311,8 @@ func moving_origin(delta):
 				i.global_position.x += 10 * delta
 
 				offset(i)
-			
-			
+
+
 		if main.can_scroll:
 			if Input.is_action_pressed("ctrl"):
 				if Input.is_action_just_pressed("lmb"):
@@ -325,12 +338,12 @@ func moving_sprite(delta):
 				i.position.y += 10 * delta
 				i.sprite_data.position.y += 10 * delta
 				update_spins()
-				
+
 			if Input.is_action_pressed("a"):
 				i.position.x -= 10 * delta
 				i.sprite_data.position.x -= 10 * delta
 				update_spins()
-				
+
 			elif Input.is_action_pressed("d"):
 				i.position.x += 10 * delta
 				i.sprite_data.position.x += 10 * delta

--- a/Scripts/Objects/ObjectComponents/movements.gd
+++ b/Scripts/Objects/ObjectComponents/movements.gd
@@ -66,7 +66,7 @@ func _physics_process(delta: float) -> void:
 	modifier_global = modifier1_node.global_position
 	placeholder_position = modifier1_node.position
 	applied_pos =  placeholder_position
-	
+
 	if !Global.static_view && actor.rest_mode != 4:
 		if (actor.rest_mode == 2 or actor.rest_mode == 3) && rest:
 			rest_mode_movements(delta)
@@ -89,10 +89,13 @@ func _physics_process(delta: float) -> void:
 	else:
 		follow_wiggle(delta)
 	if !Global.static_view:
-		var final_rot = applied_rotation + rot_drag + follow_point_rot + should_rot_rotation+ hit_rotation
+		var final_rot: float = applied_rotation + rot_drag + follow_point_rot + should_rot_rotation + hit_rotation
 		modifier_node.rotation = GlobalCalculations.is_nan_or_inf(final_rot)
-		modifier_node.position = GlobalCalculations.is_nan_or_inf(applied_pos)
-	
+		var final_position: Vector2 = GlobalCalculations.is_nan_or_inf(applied_pos)
+		if Global.grid_snap:
+			final_position = Global.snap_position(final_position)
+		modifier_node.position = final_position
+
 	shadow_target = modifier_node.global_position + follow_component.final_target
 	if actor.get_value("index_change") != 0 or actor.get_value("index_change_y") != 0:
 		var test = (shadow_target - actor.global_position).normalized()
@@ -105,17 +108,17 @@ func _physics_process(delta: float) -> void:
 		modifier_node.z_index = clamp(floori(index_change_len + index_change_len_y), -250, 250)
 	else:
 		modifier_node.z_index = 0
-	
+
 	chained_hit_reaction()
 	hit_rotation = lerp(hit_rotation, 0.0, 0.1)
-	
+
 	if actor.sprite_type == "Mesh" and mesh != null && is_instance_valid(mesh):
 		var can_deform : bool = false
 		if is_instance_valid(Global.mesh_text_node) && Global.mode == 2:
 			can_deform = Global.mesh_text_node.deform
 		if can_deform:
 			return
-			
+
 		if Global.static_view:
 			mesh.deform_x = 0.5
 			mesh.deform_y = 0.5
@@ -126,25 +129,25 @@ func _physics_process(delta: float) -> void:
 			var middle_x = (abs(actor.get_value("pos_x_min"))+ actor.get_value("pos_x_max"))*0.5
 			var middle_y = (abs(actor.get_value("pos_y_min"))+ actor.get_value("pos_y_max"))*0.5
 			var follow_amp = Vector2(middle_x, middle_y)
-			var final_amp = amp  + follow_amp 
+			var final_amp = amp  + follow_amp
 			if actor.get_value("physics"):
 				mesh_len +=   t
 				var dir = Vector2(actor.get_value("mesh_phys_x"), actor.get_value("mesh_phys_y")).normalized()
 				final_amp -=  (Vector2(300,300) -  abs(Vector2(actor.get_value("mesh_phys_x"), actor.get_value("mesh_phys_y"))))*dir
-				
+
 			var safe_deform_pos
 			if Tracker.working:
 				safe_deform_pos = mesh.apply_wobble_to_deformer(mesh_len , delta, final_amp, 0.08)
-				
+
 			else:
 				safe_deform_pos = mesh.apply_wobble_to_deformer(mesh_len, delta, final_amp, 0.15)
 			if abs(safe_deform_pos.x) != 0:
 				mesh.deform_x = safe_deform_pos.x
 			if abs(safe_deform_pos.y) != 0:
 				mesh.deform_y = safe_deform_pos.y
-			
+
 			mesh.call_deferred("update_physics", delta, false)
-	
+
 		last_modifier_position = last_modifier_position.lerp(%Origin.global_position,0.125 )
 
 func chained_hit_reaction():
@@ -165,7 +168,7 @@ func _process(_delta : float) -> void:
 			var parent = p.owner
 			if parent.get_value("static_obj"):
 				pos = p.to_global(object_pos)
-			
+
 		%Rotation.global_position = pos
 
 func static_prev() -> void:
@@ -187,7 +190,7 @@ func movements(delta: float) -> void:
 	if actor.get_value("ignore_bounce") && !actor.get_value("static_obj"):
 		glob -= Vector2(0.0, Global.sprite_container.bounceChange)
 	var l = glob - dragger.global_position
-	var length : float = l.y + l.x 
+	var length : float = l.y + l.x
 	length = add_parent_physics(length)
 	calc_length = length
 	stretch(calc_length)
@@ -203,12 +206,12 @@ func apply_recursive_look_at_chain(actor_node: SpriteObject) -> void:
 		if root != null and target != null:
 			var target_pos: Vector2 = target.global_position - root.global_position
 			apply_look_at_ik(target_pos, actor_node.get_node("%Rotation"))
-			
+
 			var ik_chain =  actor_node.target_ik.target_ik
 			if ik_chain != null && is_instance_valid(ik_chain):
 				var target_pos_2: Vector2 = ik_chain.get_node("%Origin").global_position - root.global_position
 				apply_look_at_ik(target_pos_2, actor_node.get_node("%Rotation"))
-				
+
 			if actor_node.has_node("%Sprite2D"):
 				var sprite_root = actor_node.get_node("%Sprite2D")
 				for child in sprite_root.get_children():
@@ -277,7 +280,7 @@ func wobble(delta: float) -> void:
 	else:
 		var wob_x : float = sin((Global.tick)*actor.get_value("xFrq"))*actor.get_value("xAmp")
 		last_wobble_pos.x = lerp(last_wobble_pos.x, wob_x, 0.5)
-	
+
 	if actor.is_default("yFrq"):
 		if actor.get_value("pause_movement"):
 			if actor.is_all_default("yFrq"):
@@ -291,7 +294,7 @@ func wobble(delta: float) -> void:
 	else:
 		var wob_y : float = sin((Global.tick)*actor.get_value("yFrq"))*actor.get_value("yAmp")
 		last_wobble_pos.y = lerp(last_wobble_pos.y, wob_y, 0.5)
-	
+
 	applied_pos.x += last_wobble_pos.x
 	applied_pos.y += last_wobble_pos.y
 
@@ -308,15 +311,15 @@ func rotational_drag(length, delta: float):
 	else:
 		last_rot = sin((Global.tick-paused_rotation) * actor.get_value("rot_frq"))
 		last_rot *= deg_to_rad(actor.get_value("rdragStr"))
-	
+
 	var min_rot : float = deg_to_rad(actor.get_value("rLimitMin"))
 	var max_rot : float = deg_to_rad(actor.get_value("rLimitMax"))
-	
+
 	var final_last_rot : float = clamp(last_rot,min_rot, max_rot)
-	
+
 	applied_rotation = lerp_angle(applied_rotation, final_last_rot, 0.15)
 	yvel = ((length * actor.get_value("rdragStr")))*(actor.get_value("phys_eff")/200.0)
-	
+
 	yvel = clamp(yvel,min_rot, max_rot)
 	applied_rotation = lerp_angle(applied_rotation,deg_to_rad(yvel),0.15)
 
@@ -335,7 +338,7 @@ func follow_wiggle(_delta : float) -> void:
 	var raw_tip : Vector2 = parent.to_global(parent.points[tip_index])
 	var real_tip : Vector2 = parent.points[tip_index]
 	var local_tip : Vector2 = actor.to_local(raw_tip)
-	
+
 	if !has_prev:
 		prev_smoothed_pos = local_tip
 		has_prev = true
@@ -351,7 +354,7 @@ func follow_wiggle(_delta : float) -> void:
 		prev_point = parent.points[tip_index - 1]
 
 	var dir : Vector2 = real_tip - prev_point
-	
+
 	var rest_angle : float = parent._rest_direction_angle
 	var target_ang : float = wrapf(dir.rotated(-rest_angle).angle(), -PI, PI)
 

--- a/Scripts/Objects/sprite_object.gd
+++ b/Scripts/Objects/sprite_object.gd
@@ -34,7 +34,7 @@ func _ready():
 	Global.deselect.connect(desel)
 	grab_object.button_down.connect(_on_grab_button_down)
 	grab_object.button_up.connect(_on_grab_button_up)
-	
+
 	await get_tree().create_timer(0.1).timeout
 	if sprite_object == null or static_collision == null: return
 	static_collision.shape.radius = 500
@@ -84,9 +84,9 @@ func animation():
 		if (get_value("hframes")*get_value("vframes")) - 1 > 1:
 			if !get_value("animate_to_mouse"):
 				%Sprite2D.frame = get_value("frame")
-	
+
 	if is_inside_tree():
-		$Animation.wait_time = 1.0/get_value("animation_speed") 
+		$Animation.wait_time = 1.0/get_value("animation_speed")
 		$Animation.start()
 
 func _process(_delta):
@@ -99,7 +99,7 @@ func _process(_delta):
 		%Selection.frame = %Sprite2D.frame
 		%Selection.flip_h = %Sprite2D.flip_h
 		%Selection.flip_v = %Sprite2D.flip_v
-		
+
 		if get_value("wiggle"):
 			%WiggleOrigin.show()
 			var pos = (%Sprite2D.material.get_shader_parameter("rotation_offset") * %Sprite2D.texture.get_size())/2
@@ -110,28 +110,30 @@ func _process(_delta):
 		else:
 			%Selection.material.set_shader_parameter("wiggle", false)
 			%WiggleOrigin.hide()
-		
+
 	else:
 		%Grab.mouse_filter = Control.MouseFilter.MOUSE_FILTER_IGNORE
 		%Selection.hide()
 		%Grab.modulate.a = 0.0
 		%WiggleOrigin.hide()
-	
+
 	if dragging:
 		var mouse_pos = get_parent().to_local(get_global_mouse_position())
 		for s in Global.held_sprites:
-			s.position = mouse_pos - drag_offsets[s]
-			s.sprite_data.position = s.position
+			var new_position: Vector2 = mouse_pos - drag_offsets[s]
+			new_position = Global.snap_position(new_position)
+			s.position = new_position
+			s.sprite_data.position = new_position
 			s.save_state(Global.current_state)
 		Global.update_pos_spins.emit()
-		
+
 	if !Global.static_view:
 		if get_value("wiggle"):
 			wiggle_sprite()
 	else:
 		if get_value("wiggle"):
 			%Sprite2D.material.set_shader_parameter("rotation", 0)
-		
+
 	advanced_lipsyc()
 
 func _on_grab_button_down():
@@ -168,9 +170,9 @@ func wiggle_sprite():
 					var c_parrent_length = movements_node.glob.y - drag_node.global_position.y
 					var c_parrent_length2 = movements_node.glob.x - drag_node.global_position.x
 					length += (c_parrent_length + c_parrent_length2) / 50.0
-	
+
 	wiggle_val = lerp(wiggle_val, sin((Global.tick * get_value("wiggle_freq"))+length)*get_value("wiggle_amp"), 0.05)
-	
+
 	if !get_parent() is Sprite2D:
 		%Sprite2D.material.set_shader_parameter("rotation", wiggle_val )
 	elif get_parent() is Sprite2D:
@@ -202,12 +204,12 @@ func get_state(id):
 		sprite_data.merge(dict, true)
 		if get_value("should_reset_state"):
 			%ReactionConfig.reset_anim()
-		
+
 		var old_glob = global_position
 		position = get_value("position")
-		%Sprite2D.position = get_value("offset") 
+		%Sprite2D.position = get_value("offset")
 		%Sprite2D.scale = Vector2(1,1)
-		
+
 		%Modifier1.z_index = get_value("z_index")
 		modulate = get_value("colored")
 		%Sprite2D.self_modulate = get_value("tint")
@@ -215,22 +217,22 @@ func get_state(id):
 		static_collision.disabled = !get_value("can_be_hit")
 		%HitDetection.set_collision_layer_value(2, get_value("can_be_hit"))
 	#	global_position = get_value("global_position")
-		
-		
+
+
 		if (global_position - old_glob).length() > get_value("drag_snap") && get_value("drag_snap") != 999999.0:
 			%Modifier.global_position = %Modifier1.global_position
 			%Dragger.global_position = %Modifier.global_position
-		
+
 		%Sprite2D.set_clip_children_mode(get_value("clip"))
 		rotation = get_value("rotation")
 		%Sprite2D.material.set_shader_parameter("wiggle", get_value("wiggle"))
 		%Sprite2D.material.set_shader_parameter("rotation_offset", get_value("wiggle_rot_offset"))
-		
+
 		if get_value("flip_sprite_h"):
 			%Sprite2D.scale.x = -1
 		else:
 			%Sprite2D.scale.x = 1
-		
+
 		if get_value("flip_sprite_v"):
 			%Sprite2D.scale.y = -1
 		else:
@@ -238,7 +240,7 @@ func get_state(id):
 
 		if get_value("advanced_lipsync"):
 			%Sprite2D.hframes = 6
-		
+
 		if !get_value("should_blink"):
 			%Modifier1.show()
 		else:
@@ -249,20 +251,20 @@ func get_state(id):
 		else:
 			modulate.a = get_value("colored").a
 			visible = get_value("visible")
-		
-			
+
+
 		animation()
 		set_blend(get_value("blend_mode"))
 		advanced_lipsyc()
-			
+
 		if !get_value("cycle") in range(Global.settings_dict.cycles.size() + 1):
 			sprite_data.cycle = 0
-		
+
 		if !get_value("should_blink"):
 			%Modifier1.modulate.a = 1
 			%Modifier1.show()
-		
-		
+
+
 	elif states[id].is_empty():
 		states[id] = sprite_data.duplicate(true)
 

--- a/Scripts/UI/Others/grid.gd
+++ b/Scripts/UI/Others/grid.gd
@@ -1,0 +1,47 @@
+extends Node2D
+
+func _ready() -> void:
+	z_index = 3000
+	visible = Global.grid_visible and Global.mode != 1
+	queue_redraw()
+
+func _process(_delta: float) -> void:
+	if visible:
+		queue_redraw()
+
+func _draw() -> void:
+	var camera := get_viewport().get_camera_2d()
+	if camera == null:
+		return
+
+	var zoom: Vector2 = camera.zoom
+	var center: Vector2 = to_local(camera.get_screen_center_position())
+	var viewport_size: Vector2 = get_viewport_rect().size / zoom
+	var half_size: Vector2 = viewport_size * 0.5 + Vector2(40.0, 40.0)
+
+	var step: float = max(Global.grid_size, 1.0)
+	var estimated_lines: float = (viewport_size.x / step) + (viewport_size.y / step)
+
+	while estimated_lines > 700.0:
+		step *= 2.0
+		estimated_lines = (viewport_size.x / step) + (viewport_size.y / step)
+
+	var min_x: float = floor((center.x - half_size.x) / step) * step
+	var max_x: float = ceil((center.x + half_size.x) / step) * step
+	var min_y: float = floor((center.y - half_size.y) / step) * step
+	var max_y: float = ceil((center.y + half_size.y) / step) * step
+
+	var minor_color := Color(0.7, 0.7, 0.7, 0.16)
+	var major_color := Color(0.7, 0.7, 0.7, 0.32)
+
+	var x: float = min_x
+	while x <= max_x:
+		var is_major: bool = is_zero_approx(fposmod(abs(x), step * 10.0))
+		draw_line(Vector2(x, min_y), Vector2(x, max_y), major_color if is_major else minor_color, 1.0)
+		x += step
+
+	var y: float = min_y
+	while y <= max_y:
+		var is_major: bool = is_zero_approx(fposmod(abs(y), step * 10.0))
+		draw_line(Vector2(min_x, y), Vector2(max_x, y), major_color if is_major else minor_color, 1.0)
+		y += step

--- a/Scripts/UI/Others/grid.gd.uid
+++ b/Scripts/UI/Others/grid.gd.uid
@@ -1,0 +1,1 @@
+uid://uwyd2fwljt6d

--- a/Scripts/UI/RightPanel/properties_script.gd
+++ b/Scripts/UI/RightPanel/properties_script.gd
@@ -7,7 +7,7 @@ func _ready() -> void:
 	%ColorPickerButton.get_picker().presets_visible = false
 	%ColorPickerButton.get_picker().color_modes_visible = false
 	%BlendMode.get_popup().id_pressed.connect(_on_blend_state_pressed)
-	
+
 	Global.deselect.connect(nullfy)
 	Global.reinfo.connect(enable)
 	Global.update_offset_spins.connect(update_offset)
@@ -48,7 +48,7 @@ func enable():
 		if i != null && is_instance_valid(i):
 			if i.sprite_type == "Comment":
 				seen_comment = true
-			
+
 			%TintPickerButton.disabled = false
 			%ColorPickerButton.disabled = false
 			%EyeOption.disabled = false
@@ -66,7 +66,7 @@ func enable():
 			%ZOrderSpinbox.editable = true
 			%EyeOption.disabled = false
 			%MouthOption.disabled = false
-			
+
 			%OffsetXSpinBox.editable = true
 			%OffsetYSpinBox.editable = true
 			if !seen_comment:
@@ -76,7 +76,7 @@ func enable():
 				%FlipSpriteH.disabled = true
 				%FlipSpriteV.disabled = true
 			%RestModeOption.disabled = false
-			
+
 			set_data()
 
 func set_data():
@@ -88,25 +88,25 @@ func set_data():
 		%ZOrderSpinbox.value = i.get_value("z_index")
 		%SizeSpinBox.value = i.get_value("scale").x
 		%SizeSpinYBox.value = i.get_value("scale").y
-		
+
 		if i.get_node("%Sprite2D").get_clip_children_mode() == 0:
 			%ClipChildren.button_pressed = false
 		else:
 			%ClipChildren.button_pressed = true
-			
+
 		%BlendMode.text = i.get_value("blend_mode")
 		%OffsetXSpinBox.value = i.get_value("offset").x
 		%OffsetYSpinBox.value = i.get_value("offset").y
-		
+
 		%PosXSpinBox.value = i.get_value("position").x
 		%PosYSpinBox.value = i.get_value("position").y
 		%RotSpinBox.value = i.get_value("rotation") / 0.01745
-		
+
 		if !%PosXSpinBox.value_changed.is_connected(_on_pos_x_spin_box_value_changed):
 			%PosXSpinBox.value_changed.connect(_on_pos_x_spin_box_value_changed)
 			%PosYSpinBox.value_changed.connect(_on_pos_y_spin_box_value_changed)
 			%RotSpinBox.value_changed.connect(_on_rot_spin_box_value_changed)
-		
+
 		if i.get_value("should_blink"):
 			if i.get_value("open_eyes"):
 				%EyeOption.select(1)
@@ -114,7 +114,7 @@ func set_data():
 				%EyeOption.select(2)
 		else:
 			%EyeOption.select(0)
-		
+
 		if i.get_value("should_talk"):
 			if i.get_value("open_mouth"):
 				%MouthOption.select(1)
@@ -122,13 +122,13 @@ func set_data():
 				%MouthOption.select(2)
 		else:
 			%MouthOption.select(0)
-		
-		
+
+
 		%RestModeOption.select(i.rest_mode)
 		if i.sprite_type == "Sprite2D":
 			%FlipSpriteH.button_pressed = i.get_value("flip_sprite_h")
 			%FlipSpriteV.button_pressed = i.get_value("flip_sprite_v")
-		
+
 		elif i.sprite_type == "WiggleApp":
 			%FlipSpriteH.button_pressed = i.get_value("flip_h")
 			%FlipSpriteV.button_pressed = i.get_value("flip_v")
@@ -138,7 +138,7 @@ func set_data():
 func _on_blend_state_pressed(id):
 	var undo_redo_data : Array = []
 	for i in Global.held_sprites:
-		var og_val = i.sprite_data.blend_mode 
+		var og_val = i.sprite_data.blend_mode
 		match id:
 			0:
 				i.sprite_data.blend_mode = "Normal"
@@ -148,21 +148,21 @@ func _on_blend_state_pressed(id):
 				i.sprite_data.blend_mode = "Subtract"
 			3:
 				i.sprite_data.blend_mode = "Multiply"
-				
+
 			4:
 				i.sprite_data.blend_mode = "Burn"
-				
+
 			5:
 				i.sprite_data.blend_mode = "HardMix"
-				
+
 			6:
 				i.sprite_data.blend_mode = "Cursed"
 		undo_redo_data.append({
 				node = i,
 				action = "blend_mode",
 				state = Global.current_state,
-				value = og_val, 
-				new_val = i.sprite_data.blend_mode 
+				value = og_val,
+				new_val = i.sprite_data.blend_mode
 			})
 		StateButton.multi_edit(i.sprite_data.blend_mode, "blend_mode", i, i.states)
 		%BlendMode.text = i.get_value("blend_mode")
@@ -216,12 +216,15 @@ func _on_tint_picker_button_color_changed(ncolor: Color) -> void:
 func _on_pos_x_spin_box_value_changed(value):
 	if %PosXSpinBox.get_line_edit().has_focus():
 		if should_change:
+			var snapped_value: float = value
+			if Global.grid_snap:
+				snapped_value = Global.snap_position(Vector2(value, 0.0)).x
 			var undo_redo_data : Array = []
 			for i in Global.held_sprites:
-				var d = submit_to_undo_redo_manager(i, "position", Global.current_state, i.position , Vector2(value,i.position.y))
-				i.sprite_data.position.x = value
-				i.position.x = value
-				StateButton.multi_edit(value, "position", i, i.states, true, "x")
+				var d = submit_to_undo_redo_manager(i, "position", Global.current_state, i.position , Vector2(snapped_value,i.position.y))
+				i.sprite_data.position.x = snapped_value
+				i.position.x = snapped_value
+				StateButton.multi_edit(snapped_value, "position", i, i.states, true, "x")
 				i.save_state(Global.current_state)
 				undo_redo_data.append(d)
 			UndoRedoManager.push_data(undo_redo_data)
@@ -229,12 +232,15 @@ func _on_pos_x_spin_box_value_changed(value):
 func _on_pos_y_spin_box_value_changed(value):
 	if %PosYSpinBox.get_line_edit().has_focus():
 		if should_change:
+			var snapped_value: float = value
+			if Global.grid_snap:
+				snapped_value = Global.snap_position(Vector2(0.0, value)).y
 			var undo_redo_data : Array = []
 			for i in Global.held_sprites:
-				var d = submit_to_undo_redo_manager(i, "position", Global.current_state, i.position , Vector2(i.position.x,value))
-				i.sprite_data.position.y = value
-				i.position.y = value
-				StateButton.multi_edit(value, "position", i, i.states, true, "y")
+				var d = submit_to_undo_redo_manager(i, "position", Global.current_state, i.position , Vector2(i.position.x,snapped_value))
+				i.sprite_data.position.y = snapped_value
+				i.position.y = snapped_value
+				StateButton.multi_edit(snapped_value, "position", i, i.states, true, "y")
 				i.save_state(Global.current_state)
 				undo_redo_data.append(d)
 			UndoRedoManager.push_data(undo_redo_data)
@@ -265,7 +271,7 @@ func _on_visible_toggled(toggled_on):
 				i.sprite_data.visible = false
 				i.visible = false
 				i.treeitem.set_button(0, 0, preload("res://UI/Assets/EyeButton2.png"))
-			
+
 			StateButton.multi_edit(i.sprite_data.visible, "visible", i, i.states)
 			i.save_state(Global.current_state)
 			undo_redo_data.append(d)
@@ -340,12 +346,12 @@ func _on_offset_x_spin_box_value_changed(value):
 				i.sprite_data.offset.x = value
 				StateButton.multi_edit(i.sprite_data.position.x, "position", i, i.states, true, "x")
 				StateButton.multi_edit(value, "offset", i, i.states, true, "x")
-				
+
 				i.get_node("%Sprite2D").position.x = i.get_value("offset").x
 				i.save_state(Global.current_state)
 				undo_redo_data.append(d)
 			UndoRedoManager.push_data(undo_redo_data)
-			
+
 		update_pos_spins()
 
 func _on_flip_sprite_h_toggled(toggled_on: bool) -> void:
@@ -359,7 +365,7 @@ func _on_flip_sprite_h_toggled(toggled_on: bool) -> void:
 					i.get_node("%Sprite2D").scale.x = -1
 				else:
 					i.get_node("%Sprite2D").scale.x = 1
-				
+
 				StateButton.multi_edit(toggled_on, "flip_sprite_h", i, i.states)
 				undo_redo_data.append(d)
 				i.save_state(Global.current_state)
@@ -389,7 +395,7 @@ func _on_flip_sprite_v_toggled(toggled_on: bool) -> void:
 				StateButton.multi_edit(toggled_on, "flip_sprite_v", i, i.states)
 				i.save_state(Global.current_state)
 				undo_redo_data.append(d)
-				
+
 			elif i.sprite_type == "WiggleApp":
 				var d = submit_to_undo_redo_manager(i, "flip_v", Global.current_state, i.sprite_data.flip_h , toggled_on)
 				i.sprite_data.flip_v = toggled_on
@@ -400,7 +406,7 @@ func _on_flip_sprite_v_toggled(toggled_on: bool) -> void:
 				StateButton.multi_edit(toggled_on, "flip_v", i, i.states)
 				i.save_state(Global.current_state)
 				undo_redo_data.append(d)
-			
+
 		UndoRedoManager.push_data(undo_redo_data)
 
 func _on_clip_children_toggled(toggled_on: bool) -> void:
@@ -434,11 +440,11 @@ func _on_eye_option_item_selected(index: int) -> void:
 				2:
 					i.sprite_data.should_blink = true
 					i.sprite_data.open_eyes = false
-				
+
 			StateButton.multi_edit(i.sprite_data.should_blink, "should_blink", i, i.states)
 			StateButton.multi_edit(i.sprite_data.open_eyes, "open_eyes", i, i.states)
-			
-		
+
+
 		Global.blink.emit()
 
 func _on_mouth_option_item_selected(index: int) -> void:
@@ -467,7 +473,7 @@ func submit_to_undo_redo_manager(node, action, state, value, new_value) -> Dicti
 				node = node,
 				action = action,
 				state = state,
-				value = value, 
+				value = value,
 				new_val =new_value
 			}
 	return d

--- a/Scripts/UI/TopPanel/TopBarInput.gd
+++ b/Scripts/UI/TopPanel/TopBarInput.gd
@@ -3,6 +3,7 @@ extends Node
 @onready var files_button: MenuButton = %FilesButton
 @onready var mode_button: MenuButton = %ModeButton
 @onready var bg_button: MenuButton = %BGButton
+@onready var grid_button: MenuButton = %GridButton
 @onready var about_button: MenuButton = %AboutButton
 @onready var window_button: MenuButton = %WindowButton
 @onready var demos_popup: PopupMenu = %Demos
@@ -36,6 +37,8 @@ var settings_scene := preload("res://UI/EditorUI/TopUI/Components/Settings_popup
 var tutorial_scene := preload("res://UI/EditorUI/TopUI/Components/tutorial_pop_up.tscn")
 
 var file_import_submenu: PopupMenu = PopupMenu.new()
+var grid_size_dialog: AcceptDialog = null
+var grid_size_spinbox: SpinBox = null
 
 @onready var file_submenu_item_demos: PopupMenu = %Demos
 
@@ -47,10 +50,13 @@ func _ready() -> void:
 	files_button.get_popup().id_pressed.connect(_on_files_id_pressed)
 	mode_button.get_popup().id_pressed.connect(_on_mode_id_pressed)
 	bg_button.get_popup().id_pressed.connect(_on_bg_id_pressed)
+	grid_button.get_popup().id_pressed.connect(_on_grid_id_pressed)
+	_setup_grid()
 	about_button.get_popup().id_pressed.connect(_on_about_id_pressed)
 	window_button.get_popup().id_pressed.connect(_on_window_id_pressed)
 
 	Global.mode_changed.connect(_on_mode_changed)
+	Global.theme_update.connect(_on_grid_theme_update)
 	Global.deselect.connect(_deselect_everything)
 	Global.dev_mode.connect(_check_dev_mode)
 
@@ -215,6 +221,9 @@ func _on_demos_id_pressed(id: int) -> void:
 
 
 func _on_mode_changed(new_mode: int) -> void:
+	if Global.grid_overlay != null and is_instance_valid(Global.grid_overlay):
+		Global.grid_overlay.visible = Global.grid_visible and new_mode != 1
+
 	match new_mode:
 		0, 2:
 			preview_mode_check.show()
@@ -264,6 +273,114 @@ func _on_about_id_pressed(id: int) -> void:
 		2:
 			get_parent().add_child(tutorial_scene.instantiate())
 
+
+func _setup_grid() -> void:
+	var overlay_script: Script = preload("res://Scripts/UI/Others/grid.gd")
+	var origin: Node2D = null
+	if Global.main != null and is_instance_valid(Global.main):
+		origin = Global.main.get_node_or_null("SubViewportContainer/SubViewport/Node2D/Origin") as Node2D
+
+	if origin == null:
+		call_deferred("_setup_grid")
+		return
+
+	if Global.grid_overlay == null or !is_instance_valid(Global.grid_overlay):
+		var overlay: Node2D = Node2D.new()
+		overlay.set_script(overlay_script)
+		overlay.name = "GridOverlay"
+		origin.add_child(overlay)
+		Global.grid_overlay = overlay
+
+	Global.grid_overlay.visible = Global.grid_visible and Global.mode != 1
+
+	var popup: PopupMenu = grid_button.get_popup()
+	popup.set_item_checked(0, Global.grid_visible)
+	popup.set_item_checked(1, Global.grid_snap)
+	popup.set_item_text(2, "Snap Size: %.1f px" % Global.grid_size)
+
+func _on_grid_id_pressed(id: int) -> void:
+	match id:
+		0:
+			Global.grid_visible = !Global.grid_visible
+			if Global.grid_overlay != null and is_instance_valid(Global.grid_overlay):
+				Global.grid_overlay.visible = Global.grid_visible
+		1:
+			Global.grid_snap = !Global.grid_snap
+			if Global.grid_snap:
+				for sprite in Global.held_sprites:
+					var snapped: Vector2 = Global.snap_position(sprite.position)
+					sprite.position = snapped
+					sprite.sprite_data.position = snapped
+					sprite.save_state(Global.current_state)
+			Global.update_pos_spins.emit()
+		2:
+			_show_grid_size_dialog()
+
+	var popup: PopupMenu = grid_button.get_popup()
+	popup.set_item_checked(0, Global.grid_visible)
+	popup.set_item_checked(1, Global.grid_snap)
+	popup.set_item_text(2, "Snap Size: %.1f px" % Global.grid_size)
+
+func _on_grid_theme_update(new_theme: Theme = null) -> void:
+	if grid_size_dialog != null and is_instance_valid(grid_size_dialog):
+		grid_size_dialog.theme = new_theme if new_theme != null else Settings.current_theme
+
+func _show_grid_size_dialog() -> void:
+	if grid_size_dialog != null and is_instance_valid(grid_size_dialog):
+		grid_size_dialog.theme = Settings.current_theme
+		grid_size_dialog.popup_centered()
+		grid_size_spinbox.grab_focus()
+		grid_size_spinbox.get_line_edit().select_all()
+		return
+
+	grid_size_dialog = AcceptDialog.new()
+	grid_size_dialog.theme = Settings.current_theme
+	grid_size_dialog.title = "Grid Snap Size"
+	grid_size_dialog.ok_button_text = "Apply"
+	grid_size_dialog.min_size = Vector2i(320, 130)
+
+	var container: VBoxContainer = VBoxContainer.new()
+	container.add_theme_constant_override("separation", 8)
+	grid_size_dialog.add_child(container)
+
+	var label: Label = Label.new()
+	label.text = "Snap distance (0.1 to 100 pixels):"
+	container.add_child(label)
+
+	grid_size_spinbox = SpinBox.new()
+	grid_size_spinbox.min_value = 0.1
+	grid_size_spinbox.max_value = 100.0
+	grid_size_spinbox.step = 0.1
+	grid_size_spinbox.value = Global.grid_size
+	grid_size_spinbox.allow_greater = false
+	grid_size_spinbox.allow_lesser = false
+	grid_size_spinbox.tooltip_text = "Distance between snap points in pixels."
+	container.add_child(grid_size_spinbox)
+
+	grid_size_dialog.confirmed.connect(_apply_grid_size)
+	get_tree().current_scene.add_child(grid_size_dialog)
+	grid_size_dialog.popup_centered()
+	grid_size_spinbox.grab_focus()
+	grid_size_spinbox.get_line_edit().select_all()
+
+func _apply_grid_size() -> void:
+	if grid_size_spinbox == null:
+		return
+	Global.grid_size = clampf(grid_size_spinbox.value, 0.1, 100.0)
+
+	if Global.grid_overlay != null and is_instance_valid(Global.grid_overlay):
+		Global.grid_overlay.queue_redraw()
+
+	if Global.grid_snap:
+		for sprite in Global.held_sprites:
+			var snapped: Vector2 = Global.snap_position(sprite.position)
+			sprite.position = snapped
+			sprite.sprite_data.position = snapped
+			sprite.save_state(Global.current_state)
+		Global.update_pos_spins.emit()
+
+	var popup: PopupMenu = grid_button.get_popup()
+	popup.set_item_text(2, "Snap Size: %.1f px" % Global.grid_size)
 
 func _notification(what: int) -> void:
 	if not Global.is_editor:

--- a/UI/EditorUI/TopUI/top_ui.tscn
+++ b/UI/EditorUI/TopUI/top_ui.tscn
@@ -164,6 +164,22 @@ popup/item_5/id = 5
 popup/item_6/text = "TR_CUSTOM"
 popup/item_6/id = 6
 
+[node name="GridButton" type="MenuButton" parent="TopBar/HBox" unique_id=985431217]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 14
+text = "Grid"
+item_count = 3
+popup/item_0/text = "Show Grid"
+popup/item_0/checkable = 1
+popup/item_0/id = 0
+popup/item_1/text = "Snap Position"
+popup/item_1/checkable = 1
+popup/item_1/id = 1
+popup/item_2/text = "Snap Size: 1.0 px"
+popup/item_2/id = 2
+
 [node name="BounceControlButton" type="MenuButton" parent="TopBar/HBox" unique_id=1613266894]
 unique_name_in_owner = true
 visible = false


### PR DESCRIPTION
I added this because when attempting to use the software for pixel art, sub-pixel movement drove me nuts.

The grid snapping has a range of 0.1 till 100 pixels, customizable through a top panel menu.

This does not interfere with the animation & physics systems at all. It's only present in editor mode.

The one thing I don't like about this implementation is using z_index to define where the grid goes, but it works for now. Just noting it for future maintainers. 

